### PR TITLE
Allow build of generic Echo Node Container on docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ LABEL Maintainer="Raiden Network Team <contact@raiden.network>"
 COPY . /echo-node
 WORKDIR /echo-node
 RUN pip install -r requirements.txt
-ENTRYPOINT [ "python", "echo_node/cli.py", "--config", "config-docker.toml" ]
+ENTRYPOINT [ "python", "echo_node/cli.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       retries: 3
 
   echo_node:
-    build: .
+    image: raidennetwork/raiden-echo-node:latest
+    command: ["--config", "config-docker.toml"]
     depends_on:
       - raiden


### PR DESCRIPTION
The `--config-file` flag was moved to the docker-compose file.
The docker-compose file now pull the image from `raidennetwork/raiden-echo-node`.
An automated build rule has been configured to automatically build a new container when`master` is updated.
