### PR TITLE
Change raiden tag in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   raiden:
-    image: raidennetwork/raiden:nightly
+    image: raidennetwork/raiden:unstable
     volumes:
       - "./raiden:/raiden"
     entrypoint: "/opt/venv/bin/python3 -m raiden --config-file /raiden/config.toml"


### PR DESCRIPTION
"raiden:nightly" tag has been removed from the Docker hub.